### PR TITLE
Filter services by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ Interactive cli-based multi-step form for creating / starting new time entries. 
 
     mite new
 
+Services can be filtered with a whitelist in the configuration file:
+
+    {
+        "whitelistedServices": ["<service name>"]
+    }
+
 ## Open
 
 Opens a specific time entry in your browser

--- a/source/mite-new.js
+++ b/source/mite-new.js
@@ -50,6 +50,9 @@ function getProjectChoices() {
 function getServiceChoices() {
   return bluebird.promisify(mite.getServices)()
     .then(response => response.map(d => d.service))
+    .then(services => config.get().whitelistedServices != null 
+        ? services.filter(service => config.get().whitelistedServices.includes(service.name))
+        : services)
     .then(services => services.map(service => {
       const nameParts = [service.name];
       if (service.billable) {


### PR DESCRIPTION
# Purpose

Filter services by name when creating a new entry. Services can be configures via a whitelist in the configuration file with the keyword `whitelistedServices` with an array containing the service name.